### PR TITLE
Hides instruction lines on Markdown preview

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,32 +1,31 @@
 ---
-name: Bug Report
-about: Experiencing issues? Unexpected Result? Starts here.
+name: Report a bug
+about: Scanner crashed? Something is not OK? Starts here.
 title: "[BUG] "
 labels: bug
 assignees: ''
 ---
 
-> Instruction: Please describe on each question as much as you can. This will speeds up our bug fixing process.
+> **NOTE**
+> Please describe on each question as much as you can. This will speeds up our bug fixing process.
 
 ## What happed? What is seems to be a bug?
-Please describe what seems to be an issue.
+<!-- Please describe what seems to be an issue. -->
+<!-- We appreciates describing your issue with pictures and screen recording. If you have any, please attatch it here (by drag and dropping) -->
 
 
 ## How to reproduce this issue
-Please describe how can WE reproduce the issue.
-1. ... I do this ...
-2. ... and this ...
-3. ... and that ...
-4. ... so I experienced this ...
+<!-- Please describe how can WE reproduce the issue. -->
+<!-- We appreciates describing your issue with pictures and screen recording. If you have any, please attatch it here (by drag and dropping) -->
 
-We appreciates describing your issue with pictures and screen recording. If you have any, please attatch it here (by drag and dropping)
 
 ## What seems to cause this issue?
-Please create a resonable guess on what might cause this issue.
+<!-- Please make a most resonable guess on what cause this issue. -->
+<!-- We appreciates describing your issue with pictures and screen recording. If you have any, please attatch it here (by drag and dropping) -->
 
 
 ## Expected behavior
-Please describe what you expect from Inventory Kamera or output files:
+<!-- Please describe what you expect; from Inventory Kamera or output files -->
 
 
 ## Info about your device
@@ -37,12 +36,12 @@ Please describe what you expect from Inventory Kamera or output files:
 
 
 ## Additional Notes / Remarks
-Add any other context about the problem and log files/report here.<br>
-If you managed to find any related or similar issue, please paste a link here.
+<!-- Add any other context about the problem and log files/report here. -->
+<!-- If you managed to find any related or similar issue, please paste a link or Issue Number here. -->
 
 
 ## Checklist before sending issue
-Here's everything you should try before sending this issue. Make sure that you have completed it accordingly.
+<!-- Here's everything you should try before sending this issue. Make sure that you have completed it accordingly. -->
 
 > Instruction: Check the tickbox by replacing [ ] with [x] (in editor) or tick it after leaving the Text Editor:
 
@@ -52,7 +51,8 @@ Here's everything you should try before sending this issue. Make sure that you h
 - [ ] I have correctly set my character and inventory keys in Inventory Kamera
 - [ ] I do NOT have any image filtering softwares enabled for Genshin (HDR, Image Sharpening, etc.)
 
+
+<!-- Instruction: If your issue does not relate to scanning issue, feel free to delete unrelated checklist below. -->
 Additional checklist for Scanning issues
-> Instruction: If your issue does not relate to scanning issue, feel free to delete any unrelated checklist.
 - [ ] I tried setting the delay to maximum and still experiencing issues.
-- [ ] I have attached media and log files that will explain what caused the issue.
+- [ ] I have attached media and log files that Inventory Kamera generates.

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -1,16 +1,17 @@
 ---
-name: Feature enhancement ideas/request
-about: Want some improvement in existing feature? Starts here.
+name: Feature Enhancement request
+about: Wants improvement in working, existing feature? Starts here.
 title: "[ENHANCEMENT] "
 labels: enhancement
 assignees: ''
-
 ---
 
-## What feature are you requesting?
-Please describe what you want from this feature. Feel free to add media to support your ideas.
+> **NOTE**
+> Please describe on each question as much as you can.
 
+## What feature are you requesting?
+<!-- Please describe what you want from this feature. Feel free to add media to support your ideas. -->
 
 
 ## What can we get from this feature?
-Please persuade us on what, why, and how this feature will benefits you and everyone else.
+<!-- Please persuade us on what, why, and how this feature will benefits you and everyone else. -->

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -1,6 +1,6 @@
 ---
-name: Feature Enhancement request
-about: Wants improvement in working, existing feature? Starts here.
+name: Request an improvement
+about: Wants enhancement in a working, existing feature? Starts here.
 title: "[ENHANCEMENT] "
 labels: enhancement
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -4,14 +4,24 @@ about: Wants improvement in working, existing feature? Starts here.
 title: "[ENHANCEMENT] "
 labels: enhancement
 assignees: ''
+
 ---
 
 > **NOTE**
 > Please describe on each question as much as you can.
 
-## What feature are you requesting?
+## What existing feature are you requesting from?
 <!-- Please describe what you want from this feature. Feel free to add media to support your ideas. -->
+
+
+## Where in the existing feature seems to bug you?
+<!-- What causes you to create this issue and what is bad about it? -->
+
+
+## What are you proposing implimentation / difference ?
+<!-- What do you want us to do in order to satisfy you and others -->
 
 
 ## What can we get from this feature?
 <!-- Please persuade us on what, why, and how this feature will benefits you and everyone else. -->
+<!-- If there is an issue related to this proposal, please attatch it here. -->

--- a/.github/ISSUE_TEMPLATE/fallback_template.md
+++ b/.github/ISSUE_TEMPLATE/fallback_template.md
@@ -1,5 +1,5 @@
 ---
-name: Questions
+name: Ask a question
 about: Have a question? Is this a feature or a bug? Starts here.
 title: "[QUESTION] "
 labels: question

--- a/.github/ISSUE_TEMPLATE/fallback_template.md
+++ b/.github/ISSUE_TEMPLATE/fallback_template.md
@@ -1,33 +1,27 @@
 ---
 name: Questions
-about: If you can't find any template that suits you, starts here.
+about: Have a question? Is this a feature or a bug? Starts here.
 title: "[QUESTION] "
 labels: question
 assignees: ''
 ---
 
-> Instruction: Please describe on each question as much as you can. This will speeds up our bug fixing process.
+> **NOTE**
+> Please describe on each question as much as you can.
 
-## What happed?
-Please describe what seems to be an issue / question.
+## What seems to be an issue / question?
+<!-- Please describe what seems to be an issue / question? -->
+<!-- We appreciates describing your issue with pictures and screen recording. If you have any, please attatch it here (by drag and dropping) -->
 
 
 ## What have you done / tried?
-Please describe on what you have been testing.<br>
-We appreciates describing your issue with pictures and screen recording. If you have any, please attatch it here (by drag and dropping)
-
-
-## Info about your device
-- Device Operating System :
-- Genshin Impact Version :
-- Inventory Kamera Version :
-- Screen resolution(s) affected :
+<!-- Please describe on what you have been testing. -->
+<!-- We appreciates describing your issue with pictures and screen recording. If you have any, please attatch it here (by drag and dropping) -->
 
 
 ## Checklist before sending issue
-Here's everything you should try before sending this issue. Make sure that you have completed it accordingly.
+<!-- Here's everything you should try before sending this issue. Make sure that you have completed it accordingly. -->
 
 > Instruction: Check the tickbox by replacing [ ] with [x] (in editor) or tick it after leaving the Text Editor:
 
-- [ ] I do NOT have any image filtering softwares enabled for Genshin (HDR, Image Sharpening, etc.)
 - [ ] I have checked Issue page and there is **none** similar/unrelated to mine.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature Request
+name: Request a new feature
 about: Got features in mind? Starts here.
 title: "[FEATURE] "
 labels: enhancement
@@ -7,10 +7,19 @@ assignees: ''
 
 ---
 
-## What feature are you requesting?
-Please describe what you want from this feature. Feel free to add media to support your ideas.
+> **NOTE**
+> Please describe on each question as much as you can.
 
+## What feature are you proposing?
+<!-- Please describe what you want from this feature. -->
+<!-- We appreciates describing your issue with pictures and screen recording. If you have any, please attatch it here (by drag and dropping) -->
+
+
+## Is there's a workaround? If exists, please explain.
+<!-- Please explain what is your workaround to this feature? (if possible) -->
+<!-- e.g. Manually input the information to export files  -->
 
 
 ## What can we get from this feature?
-Please persuade us on what, why, and how this feature will benefits you and everyone else.
+<!-- Please persuade us on what, why, and how this feature will benefits you and everyone else. -->
+<!-- If there is an issue related to this proposal, please attatch it here. -->


### PR DESCRIPTION
This PR will hide all the instructions in the template for a more readable Issue report.